### PR TITLE
Set the Makefile as the source of truth for commands.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,8 @@ jobs:
       - name: Install dependencies with pipenv
         run: make install
 
-      - run: pipenv run isort --recursive --diff .
-      - run: pipenv run black --check .
-      - run: pipenv run flake8
-      - run: pipenv run mypy
-      - run: pipenv run pytest --cov --cov-fail-under=100
+      - name: Run tests and linters
+        run: make test-full
 
   docker-image:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,15 @@ repos:
     name: isort
     stages: [commit]
     language: system
-    entry: pipenv run isort
+    entry: pipenv run isort --profile black
+    types: [python]
+
+  - id: isort-full
+    name: isort
+    stages: [post-commit]
+    always_run: true
+    language: system
+    entry: pipenv run isort --profile black --diff .
     types: [python]
 
   - id: black
@@ -17,6 +25,14 @@ repos:
     stages: [commit]
     language: system
     entry: pipenv run black
+    types: [python]
+
+  - id: black-full
+    name: black
+    stages: [post-commit]
+    always_run: true
+    language: system
+    entry: pipenv run black --check .
     types: [python]
 
   - id: flake8
@@ -27,9 +43,27 @@ repos:
     types: [python]
     exclude: setup.py
 
-  - id: mypy
+  - id: flake8-full
+    name: flake8
+    stages: [post-commit]
+    always_run: true
+    language: system
+    entry: pipenv run flake8
+    types: [python]
+    exclude: setup.py
+
+  - id: mypy-full
     name: mypy
     stages: [commit]
+    language: system
+    entry: pipenv run mypy
+    types: [python]
+    require_serial: true
+
+  - id: mypy-full
+    name: mypy
+    stages: [post-commit]
+    always_run: true
     language: system
     entry: pipenv run mypy
     types: [python]
@@ -43,9 +77,10 @@ repos:
     types: [python]
     pass_filenames: false
 
-  - id: pytest-cov
-    name: pytest
-    stages: [push]
+  - id: pytest-full
+    name: pytest with 100% coverage
+    stages: [post-commit]
+    always_run: true
     language: system
     entry: pipenv run pytest --cov --cov-fail-under=100
     types: [python]

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,13 @@ install:
 	pip install pipenv
 	pipenv install --deploy --dev
 
-.PHONY: lint
-lint:
-	pipenv run pre-commit run
-
-.PHONY: lint-all
-lint-all:
-	pipenv run pre-commit run --all-files
-
 .PHONY: test
 test:
-	pipenv run python -m pytest
+	pipenv run pre-commit run
+
+.PHONY: test-full
+test-full:
+	pipenv run pre-commit run --hook post-commit
 
 .PHONY: shell
 shell:


### PR DESCRIPTION
This migrates our workflow commands into the Makefile and uses pre-commit to run as much as possible.